### PR TITLE
Prevent background and menu content from expanding cell content height

### DIFF
--- a/.swiftpm/xcode/xcuserdata/ekurutepe.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/.swiftpm/xcode/xcuserdata/ekurutepe.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>SwipeActions.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>3</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwipeActions",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13)
+        .macOS(.v10_15), .iOS(.v15)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/SwipeActions/SwipeActions.swift
+++ b/Sources/SwipeActions/SwipeActions.swift
@@ -33,16 +33,16 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
     @State private var offset: CGFloat = 0
     @State private var oldOffset: CGFloat = 0
     @State private var visibleButton: VisibleButton = .none
-    
+
     /**
      To detect if drag gesture is ended because of known issue that drag gesture onEnded not called:
      https://stackoverflow.com/questions/58807357/detect-draggesture-cancelation-in-swiftui
      */
     @GestureState private var dragGestureActive: Bool = false
-    
+
     @State private var maxLeadingOffset: CGFloat = .zero
     @State private var minTrailingOffset: CGFloat = .zero
-    
+
     @State private var contentWidth: CGFloat = .zero
     @State private var isDeletedRow: Bool = false
     /**
@@ -50,7 +50,7 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
      */
     @State private var maxLeadingOffsetIsCounted: Bool = false
     @State private var minTrailingOffsetIsCounted: Bool = false
-    
+
     private let menuTyped: MenuType
     private let leadingSwipeView: Group<V1>?
     private let trailingSwipeView: Group<V2>?
@@ -60,7 +60,7 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
     private let fullSwipeRole: SwipeRole
     private let action: (() -> Void)?
     private let id: UUID = UUID()
-    
+
     init(
         menu: MenuType,
         allowsFullSwipe: Bool = false,
@@ -98,7 +98,7 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
         trailingSwipeView = nil
         self.action = action
     }
-    
+
     init(
         menu: MenuType,
         allowsFullSwipe: Bool = false,
@@ -117,13 +117,13 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
         leadingSwipeView = nil
         self.action = action
     }
-    
+
     func reset() {
         visibleButton = .none
         offset = 0
         oldOffset = 0
     }
-    
+
     var leadingView: some View {
         leadingSwipeView
             .measureSize {
@@ -157,7 +157,7 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
                 }
             }
     }
-    
+
     var swipedMenu: some View {
         HStack(spacing: 0) {
             leadingView
@@ -166,7 +166,7 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
                 .offset(x: allowsFullSwipe && offset < minTrailingOffset ? (-1 * minTrailingOffset) + offset : 0)
         }
     }
-    
+
     var slidedMenu: some View {
         HStack(spacing: 0) {
             leadingView
@@ -176,9 +176,9 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
                 .offset(x: (-1 * minTrailingOffset) + offset)
         }
     }
-    
+
     func gesturedContent(content: Content) -> some View {
-        
+
         content
             .id(id)
             .contentShape(Rectangle()) ///otherwise swipe won't work in vacant area
@@ -187,14 +187,14 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
                 contentWidth = $0.width
             }
             .gesture(
-//                DragGesture(minimumDistance: 15, coordinateSpace: .local)
+                //                DragGesture(minimumDistance: 15, coordinateSpace: .local)
                 DragGesture(minimumDistance: 15, coordinateSpace: .global)
                     .updating($dragGestureActive) { value, state, transaction in
                         state = true
                     }
                     .onChanged { value in
                         let totalSlide = value.translation.width + oldOffset
-                        
+
                         if allowsFullSwipe && ...0 ~= Int(totalSlide) {
                             withAnimation {
                                 offset = totalSlide
@@ -236,7 +236,7 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
                                 reset()
                             }
                         }
-                        
+
                         if
                             allowsFullSwipe,
                             value.translation.width < -(contentWidth * 0.7)
@@ -244,7 +244,7 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
                             withAnimation(.linear(duration: 0.3)) {
                                 offset = -contentWidth
                             }
-                            
+
                             switch fullSwipeRole {
                             case .destructive:
                                 withAnimation(.linear(duration: 0.3)) {
@@ -257,7 +257,7 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
                             default:
                                 break
                             }
-                            
+
                             action?()
                         }
                     })
@@ -312,29 +312,29 @@ struct SwipeAction<V1: View, V2: View>: ViewModifier {
                 }
             }
     }
-    
+
     public func body(content: Content) -> some View {
         switch menuTyped {
         case .slided:
-            ZStack {
-                swipeColor
-                    .zIndex(1)
-                slidedMenu
-                    .zIndex(2)
-                gesturedContent(content: content)
-                    .zIndex(3)
-            }
-            .frame(height: isDeletedRow ? 0 : nil, alignment: .top)
+            gesturedContent(content: content)
+                .zIndex(3)
+                .background {
+                    swipeColor
+                        .zIndex(1)
+                    slidedMenu
+                        .zIndex(2)
+                }
+                .frame(height: isDeletedRow ? 0 : nil, alignment: .top)
         case .swiped:
-            ZStack {
-                swipeColor
-                    .zIndex(1)
-                swipedMenu
-                    .zIndex(2)
-                gesturedContent(content: content)
-                    .zIndex(3)
-            }
-           .frame(height: isDeletedRow ? 0 : nil, alignment: .top)
+            gesturedContent(content: content)
+                .zIndex(3)
+                .background {
+                    swipeColor
+                        .zIndex(1)
+                    swipedMenu
+                        .zIndex(2)
+                }
+                .frame(height: isDeletedRow ? 0 : nil, alignment: .top)
         }
     }
 }


### PR DESCRIPTION
In the current implementation the use of `ZStack` causes the background color to expand to maximum available dimensions. This is ok if all swipeable rows are intended to be the same height but it breaks layout if you need to use rows which size themselves to their content. 

By replacing `ZStack` with `.background` modifier this issue can be resolved. Please note that this necessitates increasing the minimum iOS version to 15 which is probably fine. 